### PR TITLE
add "Used by tools" section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ and linker.
 Until Scala.js 1.0.0-M2, the CLI is part of the
 [core repository of Scala.js](https://github.com/scala-js/scala-js).
 This repository contains the CLI for later versions.
+
+Used by tools:
+* [Scalor Maven Plugin](https://github.com/random-maven/scalor-maven-plugin)


### PR DESCRIPTION
https://github.com/random-maven/scalor-maven-plugin
is next incarnation of
https://github.com/davidB/scala-maven-plugin
which uses Scala.js linker
