### PR TITLE
Support Scala.js 1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         scalaversion: ["2.11.12", "2.12.10", "2.13.1"]
-        scalajsversion: ["1.0.0"]
+        scalajsversion: ["1.5.0"]
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 os: Windows Server 2012
 environment:
   global:
-    SCALAJS_VERSION: 1.0.0
+    SCALAJS_VERSION: 1.5.0
   matrix:
     - SCALA_VERSION: 2.11.12
     - SCALA_VERSION: 2.12.10

--- a/build.sbt
+++ b/build.sbt
@@ -11,14 +11,14 @@ val cliPack =
   taskKey[File]("Pack the CLI for the current configuration")
 
 inThisBuild(Def.settings(
-  version := "1.0.1-SNAPSHOT",
+  version := "1.5.0-SNAPSHOT",
   organization := "org.scala-js",
 
-  crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"),
+  crossScalaVersions := Seq("2.12.13", "2.11.12", "2.13.5"),
   scalaVersion := crossScalaVersions.value.head,
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
-  scalaJSVersion := "1.0.0",
+  scalaJSVersion := "1.5.0",
 
   scalaJSScalaVersions := Seq(
     "2.11.12",
@@ -32,8 +32,15 @@ inThisBuild(Def.settings(
     "2.12.8",
     "2.12.9",
     "2.12.10",
+    "2.12.11",
+    "2.12.12",
+    "2.12.13",
     "2.13.0",
     "2.13.1",
+    "2.13.2",
+    "2.13.3",
+    "2.13.4",
+    "2.13.5",
   ),
 
   homepage := Some(url("https://www.scala-js.org/")),

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -48,11 +48,24 @@ test -s out || fail "scalajsp bin/Foo$.sjsir: empty output"
 scalajsp bin/Foo\$A.sjsir > out
 test -s out || fail "scalajsp bin/Foo\$A.sjsir: empty output"
 
-scalajsld -s -o test.js -mm Foo.main bin
+scalajsld -s -o test.js -mm Foo.main bin 2> test_stderr.txt
+grep -Fxq "Warning: using a single file as output (--output) is deprecated since Scala.js 1.3.0. Use --outputDir instead." test_stderr.txt \
+  || fail "expected warning. Got: $(cat test_stderr.txt)"
 test -s test.js || fail "scalajsld: empty output"
 test -s test.js.map || fail "scalajsld: empty source map"
 
-node test.js > got.run
+node test.js > got-legacy.run
+cat > want-legacy.run <<EOF
+asdf 2
+EOF
+
+diff got-legacy.run want-legacy.run
+
+mkdir test-output
+scalajsld -s --outputDir test-output --moduleSplitStyle SmallestModules --moduleKind CommonJSModule -mm Foo.main bin
+test "$(ls test-output/*.js| wc -w)" -gt "1" || fail "scalajsld: produced single js output file"
+
+node test-output/main.js > got.run
 cat > want.run <<EOF
 asdf 2
 EOF


### PR DESCRIPTION
I added scalajs 1.5.0 support. A allowed using deprecated "file as output" with warring, and ported to new API. WDYT?