### PR TITLE
Accept main methods with no arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
+/.bsp/
 /pack/
 /cli-test/

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ inThisBuild(Def.settings(
   organization := "org.scala-js",
 
   crossScalaVersions := Seq("2.11.12", "2.12.15", "2.13.6"),
-  scalaVersion := crossScalaVersions.value.head,
+  scalaVersion := crossScalaVersions.value.last,
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
   scalaJSVersion := "1.7.1",


### PR DESCRIPTION
This PR allows users to specify a main method accepting no arguments, which is useful to use methods such as `org.scalajs.testing.bridge.Bridge.start` as an entrypoint, and tweaks minor other things (`.bsp` in `.gitignore`, default to Scala 2.13.x).

Right now, arg-less entrypoints can be specified like `--mainMethod org.scalajs.testing.bridge.Bridge.start!` (`!` at the end of the method name), but let me know if you'd prefer those to be specified another way.

These changes are motivated by https://github.com/VirtusLab/scala-cli/pull/676, which runs the Scala.JS linker in an external process, rather than embedding it in the Scala CLI native image.